### PR TITLE
Remove automatic publishing with shippable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,37 +17,6 @@ task :serve do
   try "bundle exec middleman server"
 end
 
-GITHUB_REPONAME = "algorithmiaio/api-docs"
-
-desc "Generate and publish blog to gh-pages"
-namespace :shippable do
-  task :publish do
-
-    Rake::Task["build"].invoke
-
-    Dir.mktmpdir do |tmp|
-      cp_r "build/.", tmp
-
-      pwd = Dir.pwd
-      Dir.chdir tmp
-
-      try "git init"
-      try "git add ."
-      message = "Site updated at #{Time.now.utc}"
-      if ! system "git config --get user.email" then
-        config = "-c user.name='Shippable' -c user.email='devops@algorithmia.com'"
-        puts "Overriding git user config"
-      end
-      try "git #{config} commit -m #{message.inspect}"
-      try "git remote add origin git@github.com:#{GITHUB_REPONAME}.git"
-      try "git push origin master:refs/heads/gh-pages --force"
-      try "echo Site updated! 💃"
-
-      Dir.chdir pwd
-    end
-  end
-end
-
 ## Helper so we fail as soon as a command fails.
 def try(command)
   system command

--- a/shippable.yml
+++ b/shippable.yml
@@ -10,8 +10,6 @@ build:
   ci:
     - bundle install
     - bundle exec rake build
-  on_success:
-    - if [ "$BRANCH" == "master" ]; then bundle exec rake shippable:publish; fi
 
 branches:
   except:


### PR DESCRIPTION
Resolves api-docs side of [FRONTEND-1548](https://algorithmia.atlassian.net/browse/FRONTEND-1548)

Once we have the redirect to the new location set up, we should be able to stop automatically publishing this to github pages.