### PR TITLE
Explain Presence of cURL & Python Examples

### DIFF
--- a/source/includes/algo_development/_algorithmmanagement.md
+++ b/source/includes/algo_development/_algorithmmanagement.md
@@ -1,6 +1,6 @@
 # Algorithm Management
 
-Using the Algorithmia API, you can create, publish, update, and inspect individual algorithms. At present, these are only available in Python.
+Using the Algorithmia API, you can create, publish, update, and inspect individual algorithms. At present, only our Python client supports algorithm management, and we've provided cURL examples for those algorithm management endpoints which our Python client does not yet support.
 
 To try out a complete training-to-deployment pipeline, get the [runnable Jupyter Notebook](https://github.com/algorithmiaio/model-deployment).
 


### PR DESCRIPTION
Our algorithm management docs are currently a blend of cURL and Python examples. I'd like to, at a minimum, tell users why this is the case, as we work towards unifying this documentation.