### PR TITLE
extensive edits, no functionality affected

### DIFF
--- a/source/includes/_data.md
+++ b/source/includes/_data.md
@@ -2,7 +2,7 @@
 
 ### Connectors
 
-Connectors offer you a convenient API by which to access data stored across multiple storage providers, from Algorithmia's built-in data store to Amazon S3. You can learn more about the connectors Algorithmia supports [in our documentation](/developers/data). The various connector types are identified as follows:
+Connectors offer you a convenient API through which to access data stored across multiple storage providers, from Algorithmia's built-in data store to Amazon S3. You can learn more about the connectors Algorithmia supports [in our documentation](/developers/data). The various connector types are identified as follows:
 
 - `data`: Algorithmia's built-in data storage solution.
 - `azureblob`: Microsoft Azure Blob Storage
@@ -17,24 +17,24 @@ For example, if you create an S3 data connector with the label `test`, you would
 ### Data URIs
 
 ```yaml
-# Identifies a file housed by Algorithmia's internal storage provider (data://),
+# Identifies a file hosted by Algorithmia's internal storage provider (data://),
 # which belongs to the user "demo" within their "example" collection.
 data://demo/example/test.png
 
-# Identifies a file housed in S3 (connected to via an S3 connector labeled "test"),
-# which resides in the "my_bucket" bucket and "example" directory.
+# Identifies a file hosted in S3 (connected to via an S3 connector labeled "test"),
+# which resides in the "my_bucket" bucket and "example" folder.
 s3+test://my_bucket/example/test.png
 
-# Identifies a file housed in a user's default Azure Blob data connector,
-# which resides under the "example" directory within the relevant blob container.
+# Identifies a file hosted in a user's default Azure Blob data connector,
+# which resides under the "example" folder within the relevant blob container.
 azureblob://example/test.png
 ```
 
-Algorithmia supports a *data URI* notation for identifying files and directories across connectors. To construct a data URI, take the unique identifer of a given connector (such as `data`, `azureblob`, or `s3+test`) and supply that as the URI's protocol. Then append the path to the file or directory you wish to act on. See examples to the right.
+Algorithmia supports a *data URI* notation for identifying files and folders across connectors. To construct a data URI, take the unique identifer of a given connector (such as `data`, `azureblob`, or `s3+test`) and supply that as the URI's protocol. Then append the path to the file or folder you wish to act on. See examples to the right.
 
-Algorithmia will return data URIs to you identifying new files or directories you may create, and you can use these in any of our client libraries (including our Python client library) to act on those resources.
+Algorithmia will return data URIs to you identifying new files or folders you create, and you can use these in any of our client libraries (including our Python client library) to act on those resources.
 
-Paths are contextual to the data connector you are interacting with. For example, paths for the `data` connector must begin first with the username of user who owns the collection you wish to interact with (or `.my` to refer to the calling user), then the collection name, then the file (`data` does not support directories within collections). However, when interacting with an `s3` connector, you must supply the name of the bucket as the first component of the data. Ensure you carefully read [the documentation](/developers/data) for the connector you are working with.
+Each connector type requires a specific connector path structure. For example, paths for the `data` connector must begin with the username of the target collection's owner (or `.my` to refer to the calling user), then the collection name, and then the file name (`data` does not support folders within collections). However, when interacting with an `s3` connector, you must supply the name of the bucket as the first component of the connector path. See [the documentation](/developers/data) for the exact specifications for the connector you are using.
 
 #### 
  
@@ -66,7 +66,7 @@ Paths are contextual to the data connector you are interacting with. For example
 |-|-|-|
 |`name`|String|The name of the folder.|
 
-## Create a directory
+## Create a folder
 
 ```shell
 curl https://api.algorithmia.com/v1/connector/data/demo \
@@ -100,14 +100,14 @@ example_collection.create(ReadAcl.public)
 
 |Parameter|Type|Description|
 |-|-|-|
-|`connector_id`|String|The ID of the specific connector you wish to create directory within. Learn more in the [connectors section](#connectors) above.|
-|`connector_path`|String|The path under which you wish to create the directory. Note that this path is contextual to the type of connector you are interacting with.|
+|`connector_id`|String|The ID of the specific connector within which you wish to create the folder. Learn more in the [connectors section](#connectors) above.|
+|`connector_path`|String|The path under which you wish to create the folder. Note that the format of this path is specific to the type of connector with which you are interacting.|
 
 ### Payload Parameters
 
 |Parameter|Type|Description|
 |-|-|-|
-|`name`|String|*Required*. The name of the directory you wish to create at the location specified by `connector_path`.|
+|`name`|String|*Required*. The name of the folder you wish to create at the location specified by `connector_path`.|
 |`acl.read`|Array|Used to set the ACL for [hosted data collections](/developers/data/hosted) only. Choose from `[]` (only you may access), `["algo://.my/*"]` (only your algorithms may access), and `["user://*"]` (any user may access).|
 
 ### Returns
@@ -118,11 +118,11 @@ example_collection.create(ReadAcl.public)
 }
 ```
 
-Returns the following JSON payload upon successful directory creation, otherwise an [error](#errors).
+The following JSON payload upon successful folder creation, otherwise an [error](#errors).
 
 |Attribute|Type|Description|
 |-|-|-|
-|`result`|String|The data URI of the resulting directory.|
+|`result`|String|The data URI of the resulting folder.|
 
 ## Get a file
 
@@ -159,16 +159,13 @@ exampleBytes = client.file("data://demo/example_collection/example.png").getByte
 |Parameter|Type|Description|
 |-|-|-|
 |`connector_id`|String|The ID of the specific connector from which you wish to retrieve data. Learn more in the [connectors section](#connectors) above.|
-|`connector_path`|String|The connector path for which you wish to retrieve contents.|
+|`connector_path`|String|The connector path from which you wish to retrieve data.|
 
 ### Returns
 
-The file's contents and an `X-Data-Type` response header with the value `file`.
+The file's contents and an `X-Data-Type` response header with the value `file`, otherwise an [error](#errors).
 
-Otherwise, an [error object](#errors) will be returned to you.
-
-
-## List directory contents
+## List folder contents
 
 ```shell
 curl https://api.algorithmia.com/v1/connector/data/demo/collection_name \
@@ -180,13 +177,13 @@ import Algorithmia
 
 client = Algorithmia.client('API_KEY')
 
-# Get directory's contents as a string
+# Get folder's contents as a string
 exampleText = client.file("data://demo/example_collection").getString()
 
-# Get directory's contents as JSON
+# Get folder's contents as JSON
 exampleJson =  client.file("data://demo/example_collection").getJson()
 
-# Get directory's contents as a byte array
+# Get folder's contents as a byte array
 exampleBytes = client.file("data://demo/example_collection").getBytes()
 ```
 
@@ -197,18 +194,16 @@ exampleBytes = client.file("data://demo/example_collection").getBytes()
 |Parameter|Type|Description|
 |-|-|-|
 |`connector_id`|String|The ID of the specific connector from which you wish to retrieve data. Learn more in the [connectors section](#connectors) above.|
-|`connector_path`|String|The connector path for which you wish to list contents.|
+|`connector_path`|String|The connector path from which you wish to retrieve data.|
 
 ### Returns
 
-The directory's contents described by the following JSON structure, and a `X-Data-Type` response header with the value `directory`.
+The folder's contents described by the following JSON structure, and a `X-Data-Type` response header with the value `directory`, otherwise an [error](#errors).
 
 |Attribute|Type|Description|
 |-|-|-|
 |`folders`|String|A list of zero or more [folders](#the-folder-object) stored at this path.|
 |`files`|String|A list of zero or more [files](#the-file-object) stored at this path.|
-
-Otherwise, an [error object](#errors) will be returned to you.
 
 ## Update collection ACL
 
@@ -292,8 +287,8 @@ client.file("data://demo/example_collection/example.json").putJson({"hello": "wo
 
 |Parameter|Type|Description|
 |-|-|-|
-|`connector_id`|String|The ID of the specific connector you wish to create interact with. Learn more in the [connectors section](#connectors) above.|
-|`connector_path`|String|The path at which your new file should exist. Note that this path is contextual to the type of connector you are interacting with.|
+|`connector_id`|String|The ID of the specific connector with which you wish to interact. Learn more in the [connectors section](#connectors) above.|
+|`connector_path`|String|The path at which your new file should exist. Note that the format of this path is specific to the type of connector with which you are interacting.|
 
 ### Payload Parameters
 
@@ -307,7 +302,7 @@ The body of the request will become the contents of the file that is created.
 }
 ```
 
-Returns the following JSON payload upon successful upload, otherwise an [error](#errors).
+The following JSON payload upon successful upload, otherwise an [error](#errors).
 
 |Attribute|Type|Description|
 |-|-|-|
@@ -336,14 +331,14 @@ if client.file("data://demo/example_collection/example.png").exists():
 
 |Parameter|Type|Description|
 |-|-|-|
-|`connector_id`|String|The ID of the specific connector you wish to create interact with. Learn more in the [connectors section](#connectors) above.|
-|`connector_path`|String|The path to the file or directory you wish to verify. Note that this path is contextual to the type of connector you are interacting with.|
+|`connector_id`|String|The ID of the specific connector with which you wish to interact. Learn more in the [connectors section](#connectors) above.|
+|`connector_path`|String|The path to the file or folder you wish to verify. Note that the format of this path is specific to the type of connector with which you are interacting.|
 
 ### Returns
 
-Returns an affirmative response if the file exists (such as a 200 status code), otherwise an [error](#errors).
+An affirmative response (such as a `200` status code) if the file exists, otherwise an [error](#errors).
 
-## Delete a file or directory
+## Delete a file or folder
 
 ```shell
 curl https://api.algorithmia.com/v1/connector/data/demo/example_collection/example.txt \
@@ -367,14 +362,14 @@ exampleFile.delete()
 
 |Parameter|Type|Description|
 |-|-|-|
-|`connector_id`|String|The ID of the specific connector you wish to create interact with. Learn more in the [connectors section](#connectors) above.|
-|`connector_path`|String|The path to the file or directory you wish to delete. Note that this path is contextual to the type of connector you are interacting with.|
+|`connector_id`|String|The ID of the specific connector with which you wish to interact. Learn more in the [connectors section](#connectors) above.|
+|`connector_path`|String|The path to the file or folder you wish to delete. Note that this path is contextual to the type of connector with which you are interacting.|
 
 ### Query Parameters
 
 |Parameter|Type|Description|
 |-|-|-|
-|`force`|Boolean|If attempting to delete a non-empty directory, forces deletion. Defaults to `false`.|
+|`force`|Boolean|If attempting to delete a non-empty folder, forces deletion. Defaults to `false`.|
 
 ### Returns
 
@@ -383,5 +378,5 @@ A JSON payload of the following structure if the request succeeds (or succeeds p
 |Attribute|Type|Description|
 |-|-|-|
 |`result.deleted`|Number|If the deletion is successful, the total number of files deleted.|
-|`error.deleted`|Number|If an error occurred during deletion, this property indicates how many files were deleted before the error occurred.|
+|`error.deleted`|Number|If an error occurred during deletion, the total number of files deleted before the error occurred.|
 


### PR DESCRIPTION
-Change instances of 'directory' to 'folder' since that is what the API actually uses. They are also called collections, so with so many names it is clearer to at least not also call them directories.
-Make wording more consistent in many places.
-Fix typos.